### PR TITLE
[#53] fix to complicated urls

### DIFF
--- a/hipayfullservice-android/hipayfullservice/src/main/java/com/hipay/fullservice/screen/activity/ForwardWebViewActivity.java
+++ b/hipayfullservice-android/hipayfullservice/src/main/java/com/hipay/fullservice/screen/activity/ForwardWebViewActivity.java
@@ -133,14 +133,8 @@ public class ForwardWebViewActivity extends AppCompatActivity {
             //OrderRelatedRequest.OrderRelatedRequestRedirectPathPending
             //);
 
-            if (!pathSegments.isEmpty() && pathSegments.size() == 4) {
-
-                if (
-                        pathSegments.get(0).equalsIgnoreCase(OrderRelatedRequest.GatewayCallbackURLPathName) &&
-                                pathSegments.get(1).equalsIgnoreCase(OrderRelatedRequest.GatewayCallbackURLOrderPathName) &&
-
-                                transactionStatus.containsKey(pathSegments.get(3))
-                        )
+            if (!pathSegments.isEmpty()) {
+                if (transactionStatus.containsKey(pathSegments.get(pathSegments.size() - 1)))
                 {
 
                     transaction = Transaction.fromUri(data);


### PR DESCRIPTION
remove the check for all the pathSegments in ForwardWebViewActivity#transactionFromCallbackIntent. Just check the last one which is really usefull